### PR TITLE
Major changes

### DIFF
--- a/CUE4Parse/Owen.cs
+++ b/CUE4Parse/Owen.cs
@@ -12,19 +12,14 @@ namespace CUE4Parse
         public static int Partition = 0;
         public static List<string> Paths = new();
         public static List<long> Offsets = new();
-        public static long FirstOffset = PullOffset();
-        public static bool IsExporting = false;
-
-        private static long PullOffset()
+        public static long FirstOffset
         {
-            if (Offsets.Count == 0)
+            get
             {
-                return 0;
-            }
-            else
-            {
-                return Offsets[0];
+                return Offsets.Count == 0 ? 0 : Offsets[0];
             }
         }
+
+        public static bool IsExporting = false;
     }
 }

--- a/CUE4Parse/Owen.cs
+++ b/CUE4Parse/Owen.cs
@@ -11,15 +11,18 @@ namespace CUE4Parse
         public static string Path = string.Empty;
         public static int Partition = 0;
         public static List<string> Paths = new();
-        public static List<long> Offsets = new();
-        public static long FirstOffset
-        {
-            get
-            {
-                return Offsets.Count == 0 ? 0 : Offsets[0];
-            }
-        }
+        public static Stack<long> Offsets = new();
 
         public static bool IsExporting = false;
+
+        public static Stack<T> Reverse<T>(this Stack<T> stack)
+        {
+            var newStack = new Stack<T>();
+            while (stack.Count > 0)
+            {
+                newStack.Push(stack.Pop());
+            }
+            return newStack;
+        }
     }
 }

--- a/CUE4Parse/Owen.cs
+++ b/CUE4Parse/Owen.cs
@@ -12,7 +12,19 @@ namespace CUE4Parse
         public static int Partition = 0;
         public static List<string> Paths = new();
         public static List<long> Offsets = new();
-        public static long FirstOffset = Offsets[0];
+        public static long FirstOffset = PullOffset();
         public static bool IsExporting = false;
+
+        private static long PullOffset()
+        {
+            if (Offsets.Count == 0)
+            {
+                return 0;
+            }
+            else
+            {
+                return Offsets[0];
+            }
+        }
     }
 }

--- a/CUE4Parse/UE4/IO/IoStoreReader.cs
+++ b/CUE4Parse/UE4/IO/IoStoreReader.cs
@@ -241,7 +241,7 @@ namespace CUE4Parse.UE4.IO
                 {
                     Owen.Path = Path;
                     Owen.Partition = partitionIndex;
-                    Owen.Offsets.Add(partitionOffset);
+                    Owen.Offsets.Push(partitionOffset);
                 }
 
                 FArchive reader;
@@ -279,6 +279,8 @@ namespace CUE4Parse.UE4.IO
                 reader.Position = 0;
             }
 
+            Owen.Offsets = Owen.Offsets.Reverse();
+            
             return dst;
         }
 

--- a/Custom Texture Importer/Custom Texture Importer.csproj
+++ b/Custom Texture Importer/Custom Texture Importer.csproj
@@ -5,7 +5,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Custom_Texture_Importer</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+        <Nullable>disable</Nullable>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     </PropertyGroup>
 

--- a/Custom Texture Importer/Models/Config.cs
+++ b/Custom Texture Importer/Models/Config.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Custom_Texture_Importer.Utils;
 using System.Reflection;
 
 namespace Custom_Texture_Importer.Models
@@ -24,6 +25,8 @@ namespace Custom_Texture_Importer.Models
         {
             [JsonProperty]
             public string BackupFileName { get; set; } = "OwenClient";
+            [JsonProperty]
+            public string PakPath { get; set; } = FortniteUtil.PakPath;
             [JsonProperty]
             public ConsoleColor InfoColor { get; set; } = ConsoleColor.Green;
             [JsonProperty]

--- a/Custom Texture Importer/Models/Config.cs
+++ b/Custom Texture Importer/Models/Config.cs
@@ -1,29 +1,31 @@
 ﻿using Newtonsoft.Json;
+using System.Reflection;
 
 namespace Custom_Texture_Importer.Models
 {
     public static class Config
     {
-        private const string ConfigPath = "config.json";
+        public const string CONFIG_PATH = "config.json";
 
         public static ConfigObj CurrentConfig = new ConfigObj();
         public static void InitConfig()
         {
-            if (!File.Exists(ConfigPath))
-                File.WriteAllText(ConfigPath, JsonConvert.SerializeObject(new ConfigObj(), Formatting.Indented));
+            if (!File.Exists(CONFIG_PATH))
+                File.WriteAllText(CONFIG_PATH, JsonConvert.SerializeObject(new ConfigObj(), Formatting.Indented));
 
-            CurrentConfig = JsonConvert.DeserializeObject<ConfigObj>(File.ReadAllText(ConfigPath));
+            CurrentConfig = JsonConvert.DeserializeObject<ConfigObj>(File.ReadAllText(CONFIG_PATH));
+            SaveConfig();
         }
         public static void SaveConfig()
         {
-            File.WriteAllText(ConfigPath, JsonConvert.SerializeObject(CurrentConfig));
+            File.WriteAllText(CONFIG_PATH, JsonConvert.SerializeObject(CurrentConfig));
         }
         public class ConfigObj
         {
             [JsonProperty]
             public string BackupFileName { get; set; } = "OwenClient";
             [JsonProperty]
-            public ConsoleColor SystemColor { get; set; } = ConsoleColor.Green;
+            public ConsoleColor InfoColor { get; set; } = ConsoleColor.Green;
             [JsonProperty]
             public ConsoleColor ErrorColor { get; set; } = ConsoleColor.Red;
             [JsonProperty]
@@ -34,6 +36,32 @@ namespace Custom_Texture_Importer.Models
             public ConsoleColor ProgressBarColor { get; set; } = ConsoleColor.Blue;
             [JsonProperty]
             public bool RpcIsEnabled { get; set; } = true;
+
+            /// <summary>
+            /// This ToString returns a string representation of each JsonProperty in the current instance of this class.
+            /// This way we never need to add a new string to the ToString, instead it gets all properties name and value.
+            /// </summary>
+            /// <returns></returns>
+            public override string ToString()
+            {
+                var properties = typeof(ConfigObj).GetProperties();
+                var serializableProperties = new List<PropertyInfo>();
+                foreach (var property in properties)
+                {
+                    if (property.GetCustomAttribute<JsonPropertyAttribute>() != null)
+                    {
+                        serializableProperties.Add(property);
+                    }
+                }
+
+                var result = "";
+                foreach (var property in serializableProperties)
+                {
+                    result += $"{property.Name}: {property.GetValue(this)}\n";
+                }
+
+                return result;
+            }
         }
     }
 }

--- a/Custom Texture Importer/Models/Config.cs
+++ b/Custom Texture Importer/Models/Config.cs
@@ -2,7 +2,7 @@
 
 namespace Custom_Texture_Importer.Models
 {
-    public class Config
+    public static class Config
     {
         private const string ConfigPath = "config.json";
 
@@ -10,7 +10,7 @@ namespace Custom_Texture_Importer.Models
         public static void InitConfig()
         {
             if (!File.Exists(ConfigPath))
-                File.WriteAllText(ConfigPath, JsonConvert.SerializeObject(new ConfigObj()));
+                File.WriteAllText(ConfigPath, JsonConvert.SerializeObject(new ConfigObj(), Formatting.Indented));
 
             CurrentConfig = JsonConvert.DeserializeObject<ConfigObj>(File.ReadAllText(ConfigPath));
         }
@@ -20,8 +20,20 @@ namespace Custom_Texture_Importer.Models
         }
         public class ConfigObj
         {
+            [JsonProperty]
             public string BackupFileName { get; set; } = "OwenClient";
-            public bool rpcIsEnabled { get; set; } = true;
+            [JsonProperty]
+            public ConsoleColor SystemColor { get; set; } = ConsoleColor.Green;
+            [JsonProperty]
+            public ConsoleColor ErrorColor { get; set; } = ConsoleColor.Red;
+            [JsonProperty]
+            public ConsoleColor WarningColor { get; set; } = ConsoleColor.Yellow;
+            [JsonProperty]
+            public ConsoleColor InputColor { get; set; } = ConsoleColor.Cyan;
+            [JsonProperty]
+            public ConsoleColor ProgressBarColor { get; set; } = ConsoleColor.Blue;
+            [JsonProperty]
+            public bool RpcIsEnabled { get; set; } = true;
         }
     }
 }

--- a/Custom Texture Importer/Program.cs
+++ b/Custom Texture Importer/Program.cs
@@ -27,6 +27,7 @@ public static class Program
         WARNING_COLOR = Config.CurrentConfig.WarningColor;
         INPUT_COLOR = Config.CurrentConfig.InputColor;
         PROGRESS_BAR_COLOR = Config.CurrentConfig.ProgressBarColor;
+        FortniteUtil.PakPath = Config.CurrentConfig.PakPath;
 
         RichPresenceClient.Start();
 
@@ -174,6 +175,15 @@ public static class Program
 
     private static bool CheckForCommands(string input)
     {
+        unsafe
+        {
+            string s = "Hello";
+            fixed (char* c = s)
+            {
+                *c = 'H';
+            }
+        }
+        
         if (input[0] == '#')
         {
             input = input[1..(!input.Contains(' ') ? input.Length : input.IndexOf(' '))].ToLower();
@@ -203,6 +213,11 @@ public static class Program
                     break;
                 case "config.open":
                     Process.Start("Notepad", Config.CONFIG_PATH);
+                    break;
+                case "pakpath.edit":
+                    var path = Console.ReadLine();
+                    Config.CurrentConfig.PakPath = path;
+                    Config.SaveConfig();
                     break;
                 case "help":
                     WriteLineColored(INFO_COLOR, "Commands:");

--- a/Custom Texture Importer/Program.cs
+++ b/Custom Texture Importer/Program.cs
@@ -90,7 +90,7 @@ public static class Program
                 var intAsBytes = BitConverter.GetBytes((ushort)compressed.Length);
                 utocStream.Write(intAsBytes, 0, intAsBytes.Length);
 
-                progress.Report((double)i / (chunked.Count - 1));
+                progress.Report((double)i / (chunked.Count - 1), 50);
             }
 
             await File.WriteAllBytesAsync(
@@ -153,12 +153,20 @@ public static class Program
                     await Backup.BackupFile(Owen.Path);
                     WriteLineColored(SYSTEM_COLOR, "Backed up files");
                     break;
+                case "colors":
+                    // Print each color and it's value from ConsoleColor enum
+                    foreach (var color in Enum.GetValues(typeof(ConsoleColor)))
+                    {
+                        WriteLineColored((ConsoleColor)color, $"{color} = {(int)color}");
+                    }
+                    break;
                 case "help":
                     WriteLineColored(SYSTEM_COLOR, "Commands:");
                     WriteLineColored(SYSTEM_COLOR, "exit - Exits the program");
                     WriteLineColored(SYSTEM_COLOR, "cls - Clears the console");
                     WriteLineColored(SYSTEM_COLOR, "restore - Removes duped files");
                     WriteLineColored(SYSTEM_COLOR, "backup - Backups the current file");
+                    WriteLineColored(SYSTEM_COLOR, "colors - Prints all the available colors you can use for UI colors.");
                     WriteLineColored(SYSTEM_COLOR, "help - Shows this message");
                     break;
                 default:

--- a/Custom Texture Importer/Program.cs
+++ b/Custom Texture Importer/Program.cs
@@ -10,13 +10,14 @@ namespace Custom_Texture_Importer;
 
 public static class Program
 {
-#pragma warning disable CA2211
+#pragma warning disable CA2211, IDE0090
     public static ConsoleColor INFO_COLOR = ConsoleColor.Green;
     public static ConsoleColor ERROR_COLOR = ConsoleColor.Red;
     public static ConsoleColor WARNING_COLOR = ConsoleColor.Yellow;
     public static ConsoleColor INPUT_COLOR = ConsoleColor.Cyan;
     public static ConsoleColor PROGRESS_BAR_COLOR = ConsoleColor.Blue;
-#pragma warning restore CA2211
+    private static readonly object _lock = new object();
+#pragma warning restore CA2211, IDE0090
 
     public static async Task Main()
     {
@@ -134,28 +135,40 @@ public static class Program
 
     public static void WriteLineColored(ConsoleColor color, string text)
     {
-        Console.ForegroundColor = color;
-        Console.WriteLine(text);
-        Console.ResetColor();
-        Thread.Sleep(50);
+        lock (_lock)
+        {
+            Console.ForegroundColor = color;
+            Console.WriteLine(text);
+            Console.ResetColor();
+            Thread.Sleep(50);
+        }
     }
 
     public static void WriteColored(ConsoleColor color, string text)
     {
-        Console.ForegroundColor = color;
-        Console.Write(text);
-        Console.ResetColor();
-        Thread.Sleep(50);
+        lock (_lock)
+        {
+            Console.ForegroundColor = color;
+            Console.Write(text);
+            Console.ResetColor();
+            Thread.Sleep(50);
+        }
     }
 
     private static string Input(string text, out bool isCommand)
     {
-        WriteColored(INFO_COLOR, text);
-        Console.ForegroundColor = Console.ForegroundColor != INPUT_COLOR ? INPUT_COLOR : Console.ForegroundColor;
-        var input = Console.ReadLine();
-        isCommand = CheckForCommands(input);
-        Console.ResetColor();
-        Thread.Sleep(50);
+        string input = null;
+        lock (_lock)
+        {
+            WriteColored(INFO_COLOR, text);
+            Console.ForegroundColor = INPUT_COLOR;
+            input = Console.ReadLine();
+            isCommand = CheckForCommands(input);
+            Thread.Sleep(50);
+            Console.ResetColor();
+            Thread.Sleep(50);
+        }
+        
         return input;
     }
 

--- a/Custom Texture Importer/Program.cs
+++ b/Custom Texture Importer/Program.cs
@@ -164,7 +164,7 @@ public static class Program
     {
         if (input[0] == '#')
         {
-            input = input[1..(!input.Contains(' ') ? input.IndexOf(input[^1]) + 1 : input.IndexOf(' '))].ToLower();
+            input = input[1..(!input.Contains(' ') ? input.Length : input.IndexOf(' '))].ToLower();
             switch (input)
             {
                 case "exit":

--- a/Custom Texture Importer/Program.cs
+++ b/Custom Texture Importer/Program.cs
@@ -83,7 +83,8 @@ public static class Program
                 var progress = new ProgressBar();
                 for (var i = 0; i < chunked.Count; i++)
                 {
-                    var compressed = Oodle.Compress(chunked[i]);
+                    var oodle = new Oodle();
+                    var compressed = oodle.Compress(chunked[i]);
 
                     ucasStream.BaseStream.Position = Owen.FirstOffset + written;
                     ucasStream.Write(compressed, 0, compressed.Length);
@@ -103,8 +104,6 @@ public static class Program
                 await File.WriteAllBytesAsync(
                     Owen.Path.Replace("WindowsClient", Config.CurrentConfig.BackupFileName).Replace(".ucas", ".utoc"),
                     utocStream.ToArray());
-
-                Console.WriteLine();
 
                 ucasStream.Close();
                 utocStream.Close();

--- a/Custom Texture Importer/Utils/FortniteUtil.cs
+++ b/Custom Texture Importer/Utils/FortniteUtil.cs
@@ -1,4 +1,5 @@
 ﻿using Custom_Texture_Importer.Models;
+using Custom_Texture_Importer.Utils.Program;
 using Newtonsoft.Json;
 
 namespace Custom_Texture_Importer.Utils;
@@ -85,6 +86,22 @@ public class FortniteUtil
 
         return JsonConvert.DeserializeObject<InstalledApps>(File.ReadAllText(path)).InstallationList
             .FirstOrDefault(x => x.AppName == "Fortnite").AppVersion;
+    }
+
+    public static void RemoveDupedUcas()
+    {
+        var progress = new ProgressBar();
+        var files = Directory.GetFiles(PakPath);
+        for (var i = 0; i < files.Length; i++)
+        {
+            var file = files[i];
+            if (file.Contains(Config.CurrentConfig.BackupFileName))
+            {
+                File.Delete(file);
+            }
+
+            progress.Report((double)i / files.Length - 1);
+        }
     }
 }
 

--- a/Custom Texture Importer/Utils/FortniteUtil.cs
+++ b/Custom Texture Importer/Utils/FortniteUtil.cs
@@ -100,7 +100,7 @@ public class FortniteUtil
                 File.Delete(file);
             }
 
-            progress.Report((double)i / files.Length - 1, 50);
+            progress.Report((double)i / (files.Length - 1), 50);
         }
     }
 }

--- a/Custom Texture Importer/Utils/FortniteUtil.cs
+++ b/Custom Texture Importer/Utils/FortniteUtil.cs
@@ -100,7 +100,7 @@ public class FortniteUtil
                 File.Delete(file);
             }
 
-            progress.Report((double)i / files.Length - 1);
+            progress.Report((double)i / files.Length - 1, 50);
         }
     }
 }

--- a/Custom Texture Importer/Utils/FortniteUtil.cs
+++ b/Custom Texture Importer/Utils/FortniteUtil.cs
@@ -6,8 +6,19 @@ namespace Custom_Texture_Importer.Utils;
 
 public class FortniteUtil
 {
+    private static string _fortnitePath = GetFortnitePath() + @"\FortniteGame\Content\Paks";
     public static string PakPath
-        => GetFortnitePath() + @"\FortniteGame\Content\Paks";
+    {
+        get
+        {
+            return _fortnitePath;
+        }
+
+        set
+        {
+            _fortnitePath = value;
+        }
+    }
 
     public static async Task CopyFiles(string fileName)
     {

--- a/Custom Texture Importer/Utils/Libs/Provider.cs
+++ b/Custom Texture Importer/Utils/Libs/Provider.cs
@@ -8,11 +8,11 @@ using Newtonsoft.Json;
 
 namespace Custom_Texture_Importer.Utils.Libs;
 
-public class MyFileProvider
+public class FileProvider
 {
     public readonly DefaultFileProvider Provider;
 
-    public MyFileProvider()
+    public FileProvider()
     {
         if (!CheckForConnection())
             throw new HttpRequestException("No internet connection");

--- a/Custom Texture Importer/Utils/Program/Backup.cs
+++ b/Custom Texture Importer/Utils/Program/Backup.cs
@@ -26,8 +26,7 @@ public static class Backup
 
         void Report()
         {
-            progress.Report((double)j / count);
-            Thread.Sleep(50);
+            progress.Report((double)j / count, 500);
             j++;
         }
 
@@ -51,7 +50,6 @@ public static class Backup
                         if (!File.Exists(paritionPath))
                         {
                             Report();
-                            Thread.Sleep(1000);
                             break;
                         }
 
@@ -116,8 +114,7 @@ public static class Backup
             }
         }
 
-        progress.Report(1);
-        Thread.Sleep(1000);
+        progress.Report(1, 1000);
         Console.WriteLine();
         Custom_Texture_Importer.Program.WriteLineColored(Custom_Texture_Importer.Program.SYSTEM_COLOR, "Finished backing up files.");
         progress.Dispose();

--- a/Custom Texture Importer/Utils/Program/Backup.cs
+++ b/Custom Texture Importer/Utils/Program/Backup.cs
@@ -15,8 +15,7 @@ public static class Backup
         };
 
         if (fileName.Contains("ient_s")) // Check if it's partitioned
-            fileName = fileName.Split("ient_s")[0] +
-                       "ient"; // Remove the partition from the name because they don't get utocs
+            fileName = fileName.Split("ient_s")[0] + "ient"; // Remove the partition from the name because they don't get utocs
 
         const int count = 8;
         var j = 0;
@@ -33,7 +32,10 @@ public static class Backup
                                         let path = Path.Combine(FortniteUtil.PakPath, fileName + fileExt)
                                         select (fileExt, path))
         {
-            if (!File.Exists(path)) return;
+            if (!File.Exists(path))
+            {
+                return;
+            }
 
             if (fileExt is ".ucas")
             {

--- a/Custom Texture Importer/Utils/Program/Backup.cs
+++ b/Custom Texture Importer/Utils/Program/Backup.cs
@@ -22,7 +22,6 @@ public static class Backup
         var j = 0;
         Custom_Texture_Importer.Program.WriteLineColored(ConsoleColor.Green, "Backing up files...");
         var progress = new ProgressBar();
-        Thread.Sleep(1000);
 
         void Report()
         {
@@ -31,8 +30,8 @@ public static class Backup
         }
 
         foreach (var (fileExt, path) in from fileExt in fileExts
-                 let path = Path.Combine(FortniteUtil.PakPath, fileName + fileExt)
-                 select (fileExt, path))
+                                        let path = Path.Combine(FortniteUtil.PakPath, fileName + fileExt)
+                                        select (fileExt, path))
         {
             if (!File.Exists(path)) return;
 
@@ -115,7 +114,6 @@ public static class Backup
         }
 
         progress.Report(1, 1000);
-        Console.WriteLine();
         Custom_Texture_Importer.Program.WriteLineColored(Custom_Texture_Importer.Program.INFO_COLOR, "Finished backing up files.");
         progress.Dispose();
     }

--- a/Custom Texture Importer/Utils/Program/Backup.cs
+++ b/Custom Texture Importer/Utils/Program/Backup.cs
@@ -117,8 +117,9 @@ public static class Backup
         }
 
         progress.Report(1);
-        Custom_Texture_Importer.Program.WriteLineColored(ConsoleColor.Green, "Finished backing up files.");
-        Thread.Sleep(500);
+        Thread.Sleep(1000);
+        Console.WriteLine();
+        Custom_Texture_Importer.Program.WriteLineColored(Custom_Texture_Importer.Program.SYSTEM_COLOR, "Finished backing up files.");
         progress.Dispose();
     }
 }

--- a/Custom Texture Importer/Utils/Program/Backup.cs
+++ b/Custom Texture Importer/Utils/Program/Backup.cs
@@ -116,7 +116,7 @@ public static class Backup
 
         progress.Report(1, 1000);
         Console.WriteLine();
-        Custom_Texture_Importer.Program.WriteLineColored(Custom_Texture_Importer.Program.SYSTEM_COLOR, "Finished backing up files.");
+        Custom_Texture_Importer.Program.WriteLineColored(Custom_Texture_Importer.Program.INFO_COLOR, "Finished backing up files.");
         progress.Dispose();
     }
 }

--- a/Custom Texture Importer/Utils/Program/ProgressBar.cs
+++ b/Custom Texture Importer/Utils/Program/ProgressBar.cs
@@ -38,8 +38,9 @@ public class ProgressBar : IDisposable, IProgress<double>
         value = Math.Max(0, Math.Min(1, value));
         Interlocked.Exchange(ref currentProgress, value);
         Thread.Sleep(sleepTime);
-        if (value == 1)
+        if (value == 1.0)
         {
+            Thread.Sleep(100);
             Console.WriteLine();
         }
     }

--- a/Custom Texture Importer/Utils/Program/ProgressBar.cs
+++ b/Custom Texture Importer/Utils/Program/ProgressBar.cs
@@ -9,7 +9,6 @@ public class ProgressBar : IDisposable, IProgress<double>
     private readonly TimeSpan animationInterval = TimeSpan.FromSeconds(1.0 / 8);
 
     private readonly Timer timer;
-    private int animationIndex = 0;
 
     private double currentProgress;
     private string currentText = string.Empty;
@@ -39,6 +38,15 @@ public class ProgressBar : IDisposable, IProgress<double>
         value = Math.Max(0, Math.Min(1, value));
         Interlocked.Exchange(ref currentProgress, value);
         Thread.Sleep(sleepTime);
+        if (value == 1)
+        {
+            Console.WriteLine();
+        }
+    }
+
+    public void Report(double value)
+    {
+        Report(value, 100);
     }
 
     private void TimerHandler(object state)

--- a/Custom Texture Importer/Utils/Program/ProgressBar.cs
+++ b/Custom Texture Importer/Utils/Program/ProgressBar.cs
@@ -33,12 +33,12 @@ public class ProgressBar : IDisposable, IProgress<double>
         }
     }
 
-    public void Report(double value)
+    public void Report(double value, int sleepTime = 100)
     {
         // Make sure value is in [0..1] range
         value = Math.Max(0, Math.Min(1, value));
         Interlocked.Exchange(ref currentProgress, value);
-        Thread.Sleep(100);
+        Thread.Sleep(sleepTime);
     }
 
     private void TimerHandler(object state)

--- a/Custom Texture Importer/Utils/Program/ProgressBar.cs
+++ b/Custom Texture Importer/Utils/Program/ProgressBar.cs
@@ -38,6 +38,7 @@ public class ProgressBar : IDisposable, IProgress<double>
         // Make sure value is in [0..1] range
         value = Math.Max(0, Math.Min(1, value));
         Interlocked.Exchange(ref currentProgress, value);
+        Thread.Sleep(100);
     }
 
     private void TimerHandler(object state)
@@ -46,7 +47,7 @@ public class ProgressBar : IDisposable, IProgress<double>
         {
             if (disposed) return;
 
-            Console.ForegroundColor = ConsoleColor.Blue;
+            Console.ForegroundColor = Custom_Texture_Importer.Program.PROGRESS_BAR_COLOR;
             var progressBlockCount = (int)(currentProgress * blockCount);
             var percent = (int)(currentProgress * 100);
             var text = string.Format("[{0}{1}] {2,3}% {3}",

--- a/Custom Texture Importer/Utils/RichPresenceClient.cs
+++ b/Custom Texture Importer/Utils/RichPresenceClient.cs
@@ -40,7 +40,7 @@ namespace Custom_Texture_Importer.Utils
 
         public static void Start()
         {
-            if (!Models.Config.CurrentConfig.rpcIsEnabled)
+            if (!Models.Config.CurrentConfig.RpcIsEnabled)
                 return;
 
             Client = new("958805762455523358");
@@ -60,7 +60,7 @@ namespace Custom_Texture_Importer.Utils
 
         public static void UpdatePresence(string details, string State)
         {
-            if (!Models.Config.CurrentConfig.rpcIsEnabled || !Client.IsInitialized)
+            if (!Models.Config.CurrentConfig.RpcIsEnabled || !Client.IsInitialized)
                 return;
 
             _currentPresence.Details = details;


### PR DESCRIPTION
**Major changes:**

Added more UI features such as changeable colors via the config file, and more colors. 
Implemented a command system. Commands start with the prefix '#'.
Added a 'PullOffset' method which returns 0 if the length of 'Offsets' in 'Owen' class is 0.

**List of commands:**
`#exit`: Exits the program.
`#cls`: Clears the console.
`#restore`: Removes duped files.
`#backup`: Backs up the files.
`#help`: Shows list of commands

If a command is found invalid an error will print to the console telling you.
Commands will be detected on all input. 

**Colors:**
I implemented a coloring system which can be controlled via config.json. There are 5 different color systems.
SYSTEM_COLOR = ConsoleColor.Green
ERROR_COLOR = ConsoleColor.Red
WARNING_COLOR = ConsoleColor.Yellow
INPUT_COLOR = ConsoleColor.Cyan
PROGRESS_BAR_COLOR = ConsoleColor.Blue

**More Changes:**
Changed progress bar, and added new command:
`#colors`: Prints all the available colors you can use for UI colors.

New commands, and changed progress bar:
Made some minor adjustments to progress bar, and added 2 new commands:
`#config`: Prints the current config
`#config.open`: Opens the config file in notepad

Also added a progress bar for the initialization of the provider.



**Custom texture tool fixed:**

Short explanation, offsets were wrong.

Long explanation(be prepared). The way offsets were pulled was the reason the tool didn't work. Basically in the static class `Owen`, the property `FirstOffset` was pulling the first offset, but not removing it once it was used. To counter this, I removed the property 'FirstOffset' and changed the type of the field `Offsets` to type `Stack<long>`, after these changes, I went to `Program.cs` and changed the parts that grabbed the offset, to `Owen.Offsets.Pop()` which essentially takes the top value of the stack, removes it from the stack's underlying array, then returns that top value, this way we can make use of all offsets only once, and remove already used offsets.



Other minor changes:
Removed command `#backup` as it is unneeded.

I recommend using the command '#restore' to delete duped files, as manually doing it can cause those files to pile up in your recycling bin.

I partially changed how progress bar works. There are still a few UI errors I have yet to fix.

**Possible future implementations:**
I plan on adding a full fledged config editor to the program (so you don't have to open the file).

**Know UI issues:**
After using a command, coloring for input will break. - I assume this is just because console has a slow and bad interface.
Progress bar will loose color randomly. - Again, console interface is bad.
After a feature that has a progress bar, the info text will be the same color as the progress bar. - Console interface is just bad